### PR TITLE
Give enough delay to the client before opening an inventory

### DIFF
--- a/inv/menu.go
+++ b/inv/menu.go
@@ -139,7 +139,7 @@ func sendMenu(p *player.Player, m Menu, update bool) {
 	updatePrivateField(s, "openedWindowID", openedWindowIdPtr)
 
 	if !update {
-		time.AfterFunc(time.Millisecond*100, func() {
+		time.AfterFunc(time.Millisecond*500, func() {
 			session_writePacket(s, &packet.ContainerOpen{
 				WindowID:                nextID,
 				ContainerPosition:       blockPos,


### PR DESCRIPTION
100 miliseconds seem not working on certain scenarios, giving 500 should be enough. (Client need some time to get update block packet before opening inv)