### PR TITLE
feat: add anvil menus

### DIFF
--- a/inv/container.go
+++ b/inv/container.go
@@ -51,6 +51,13 @@ func (ContainerDropper) Block() world.Block { return dropper{} }
 func (ContainerDropper) Type() int          { return protocol.ContainerTypeDropper }
 func (ContainerDropper) Size() int          { return 9 }
 
+// ContainerAnvil represents an anvil container.
+type ContainerAnvil struct{}
+
+func (ContainerAnvil) Block() world.Block { return block.Anvil{Type: block.UndamagedAnvil()} }
+func (ContainerAnvil) Type() int          { return protocol.ContainerTypeAnvil }
+func (ContainerAnvil) Size() int          { return 3 }
+
 // ContainerBarrel represents a barrel container.
 type ContainerBarrel struct{}
 

--- a/inv/container_test.go
+++ b/inv/container_test.go
@@ -1,0 +1,138 @@
+package inv
+
+import (
+	"testing"
+
+	"github.com/df-mc/dragonfly/server/block"
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/item/inventory"
+	"github.com/df-mc/dragonfly/server/session"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+func TestContainerAnvil(t *testing.T) {
+	c := ContainerAnvil{}
+	if _, ok := c.Block().(block.Anvil); !ok {
+		t.Fatalf("Block() returned %T, want block.Anvil", c.Block())
+	}
+	if got := c.Type(); got != protocol.ContainerTypeAnvil {
+		t.Fatalf("Type() returned %d, want %d", got, protocol.ContainerTypeAnvil)
+	}
+	if got := c.Size(); got != 3 {
+		t.Fatalf("Size() returned %d, want 3", got)
+	}
+}
+
+func TestContainerAnvilHasNoBlockActorData(t *testing.T) {
+	if got := createFakeInventoryNBT("Anvil", ContainerAnvil{}); got != nil {
+		t.Fatalf("createFakeInventoryNBT() returned %v, want nil", got)
+	}
+}
+
+func TestContainerAnvilRewritesSpecialSlots(t *testing.T) {
+	s := &session.Session{}
+	inv := inventory.New(3, nil)
+	result := item.NewStack(block.Anvil{Type: block.UndamagedAnvil()}, 1)
+	if err := inv.SetItem(2, result); err != nil {
+		t.Fatal(err)
+	}
+	menuMu.Lock()
+	lastMenus[s] = Menu{container: ContainerAnvil{}, inventory: inv}
+	menuMu.Unlock()
+	t.Cleanup(func() {
+		menuMu.Lock()
+		delete(lastMenus, s)
+		menuMu.Unlock()
+	})
+
+	tests := []struct {
+		name string
+		id   byte
+		slot byte
+		want byte
+		idIn int32
+	}{
+		{name: "input", id: protocol.ContainerAnvilInput, slot: 1, want: 0},
+		{name: "material", id: protocol.ContainerAnvilMaterial, slot: 2, want: 1},
+		{name: "result preview", id: protocol.ContainerAnvilResultPreview, slot: 50, want: 2},
+		{name: "created output", id: protocol.ContainerCreatedOutput, slot: 50, want: 2, idIn: -1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := &protocol.TakeStackRequestAction{}
+			a.Source = protocol.StackRequestSlotInfo{
+				Container:      protocol.FullContainerName{ContainerID: test.id},
+				Slot:           test.slot,
+				StackNetworkID: test.idIn,
+			}
+			a.Destination = protocol.StackRequestSlotInfo{
+				Container: protocol.FullContainerName{ContainerID: protocol.ContainerInventory},
+			}
+
+			updateActionContainerID(a, s)
+
+			if got := a.Source.Container.ContainerID; got != protocol.ContainerLevelEntity {
+				t.Fatalf("container ID = %d, want %d", got, protocol.ContainerLevelEntity)
+			}
+			if got := a.Source.Slot; got != test.want {
+				t.Fatalf("slot = %d, want %d", got, test.want)
+			}
+			if test.idIn < 0 && a.Source.StackNetworkID != item_id(result) {
+				t.Fatalf("stack network ID = %d, want %d", a.Source.StackNetworkID, item_id(result))
+			}
+		})
+	}
+}
+
+func TestContainerAnvilRewritesDestroy(t *testing.T) {
+	s := &session.Session{}
+	menuMu.Lock()
+	lastMenus[s] = Menu{container: ContainerAnvil{}, inventory: inventory.New(3, nil)}
+	menuMu.Unlock()
+	t.Cleanup(func() {
+		menuMu.Lock()
+		delete(lastMenus, s)
+		menuMu.Unlock()
+	})
+
+	a := &protocol.DestroyStackRequestAction{Source: protocol.StackRequestSlotInfo{
+		Container: protocol.FullContainerName{ContainerID: protocol.ContainerAnvilMaterial},
+		Slot:      2,
+	}}
+	updateActionContainerID(a, s)
+
+	if got := a.Source.Container.ContainerID; got != protocol.ContainerLevelEntity {
+		t.Fatalf("container ID = %d, want %d", got, protocol.ContainerLevelEntity)
+	}
+	if got := a.Source.Slot; got != 1 {
+		t.Fatalf("slot = %d, want 1", got)
+	}
+}
+
+func TestContainerAnvilSkipsVanillaCraftActions(t *testing.T) {
+	s := &session.Session{}
+	menuMu.Lock()
+	lastMenus[s] = Menu{container: ContainerAnvil{}}
+	menuMu.Unlock()
+	t.Cleanup(func() {
+		menuMu.Lock()
+		delete(lastMenus, s)
+		menuMu.Unlock()
+	})
+
+	requests := []protocol.ItemStackRequest{{
+		Actions: []protocol.StackRequestAction{
+			&protocol.CraftRecipeOptionalStackRequestAction{},
+			&protocol.CreateStackRequestAction{},
+			&protocol.ConsumeStackRequestAction{},
+		},
+	}}
+	handleItemStackRequest(s, requests)
+
+	if got := len(requests[0].Actions); got != 1 {
+		t.Fatalf("action count = %d, want 1", got)
+	}
+	if _, ok := requests[0].Actions[0].(*protocol.ConsumeStackRequestAction); !ok {
+		t.Fatalf("remaining action has type %T, want *protocol.ConsumeStackRequestAction", requests[0].Actions[0])
+	}
+}

--- a/inv/handler_packet.go
+++ b/inv/handler_packet.go
@@ -62,16 +62,45 @@ func handleContainerClose(ctx *intercept.Context, p *player.Player, s *session.S
 }
 
 func handleItemStackRequest(s *session.Session, req []protocol.ItemStackRequest) {
-	for _, data := range req {
-		for _, action := range data.Actions {
+	_, anvil := anvilMenu(s)
+	for i := range req {
+		actions := req[i].Actions[:0]
+		for _, action := range req[i].Actions {
+			if anvil {
+				switch action.(type) {
+				case *protocol.CraftRecipeOptionalStackRequestAction, *protocol.CreateStackRequestAction:
+					continue
+				}
+			}
 			updateActionContainerID(action, s)
+			actions = append(actions, action)
 		}
+		req[i].Actions = actions
 	}
 }
 
 // updateActionContainerID updates the container ID of the given action based on the current menu state.
 // It is useful in case we use some unimplemented blocks such as hoppers.
 func updateActionContainerID(action protocol.StackRequestAction, s *session.Session) {
+	if m, ok := anvilMenu(s); ok {
+		switch act := action.(type) {
+		case *protocol.TakeStackRequestAction:
+			rewriteAnvilSlot(&act.Source, m)
+			rewriteAnvilSlot(&act.Destination, m)
+		case *protocol.PlaceStackRequestAction:
+			rewriteAnvilSlot(&act.Source, m)
+			rewriteAnvilSlot(&act.Destination, m)
+		case *protocol.DropStackRequestAction:
+			rewriteAnvilSlot(&act.Source, m)
+		case *protocol.DestroyStackRequestAction:
+			rewriteAnvilSlot(&act.Source, m)
+		case *protocol.SwapStackRequestAction:
+			rewriteAnvilSlot(&act.Source, m)
+			rewriteAnvilSlot(&act.Destination, m)
+		}
+		return
+	}
+
 	switch act := action.(type) {
 	case *protocol.TakeStackRequestAction:
 		if act.Source.Container.ContainerID != act.Destination.Container.ContainerID || act.Source.Container.ContainerID == protocol.ContainerCursor || act.Source.Container.ContainerID == protocol.ContainerHotBar {
@@ -101,6 +130,32 @@ func updateActionContainerID(action protocol.StackRequestAction, s *session.Sess
 		}
 		if _, ok := lastMenu(s); ok {
 			act.Source.Container.ContainerID = protocol.ContainerLevelEntity
+		}
+	}
+}
+
+func anvilMenu(s *session.Session) (Menu, bool) {
+	m, ok := lastMenu(s)
+	return m, ok && m.container != nil && m.container.Type() == protocol.ContainerTypeAnvil
+}
+
+func rewriteAnvilSlot(slot *protocol.StackRequestSlotInfo, m Menu) {
+	switch slot.Container.ContainerID {
+	case protocol.ContainerAnvilInput:
+		slot.Container.ContainerID = protocol.ContainerLevelEntity
+		slot.Slot = 0
+	case protocol.ContainerAnvilMaterial:
+		slot.Container.ContainerID = protocol.ContainerLevelEntity
+		slot.Slot = 1
+	case protocol.ContainerAnvilResultPreview, protocol.ContainerCreatedOutput:
+		slot.Container.ContainerID = protocol.ContainerLevelEntity
+		slot.Slot = 2
+	default:
+		return
+	}
+	if slot.StackNetworkID < 0 && m.inventory != nil {
+		if stack, err := m.inventory.Item(int(slot.Slot)); err == nil {
+			slot.StackNetworkID = item_id(stack)
 		}
 	}
 }

--- a/inv/menu.go
+++ b/inv/menu.go
@@ -114,10 +114,12 @@ func sendMenu(p *player.Player, m Menu, update bool) {
 		data["pairx"] = int32(pos[0] + 1)
 	}
 
-	session_writePacket(s, &packet.BlockActorData{
-		Position: blockPos,
-		NBTData:  data,
-	})
+	if data != nil {
+		session_writePacket(s, &packet.BlockActorData{
+			Position: blockPos,
+			NBTData:  data,
+		})
+	}
 
 	posPtr := atomic.Pointer[cube.Pos]{}
 	invPtr := atomic.Pointer[inventory.Inventory]{}
@@ -217,6 +219,9 @@ func createFakeInventoryNBT(name string, container Container) map[string]interfa
 		m["id"] = "Hopper"
 	case protocol.ContainerTypeDropper:
 		m["id"] = "Dropper"
+	case protocol.ContainerTypeAnvil:
+		// Anvils are not block actors and do not have NBT to send to the client.
+		return nil
 	default:
 		panic("should never happen")
 	}
@@ -266,3 +271,8 @@ func session_sendInv(*session.Session, *inventory.Inventory, uint32)
 //
 //go:linkname session_sendItem github.com/df-mc/dragonfly/server/session.(*Session).sendItem
 func session_sendItem(*session.Session, item.Stack, int, uint32)
+
+// noinspection ALL
+//
+//go:linkname item_id github.com/df-mc/dragonfly/server/item.id
+func item_id(item.Stack) int32


### PR DESCRIPTION
## Summary

- add `ContainerAnvil` for three-slot anvil menus
- skip block-actor NBT for anvils, which are not block actors
- translate Bedrock's special anvil input, material, and result slots to the menu inventory
- bypass vanilla crafting actions that require a real server-side anvil block
- resolve predicted result stack IDs and support creative destroy actions

## Usage

```go
menu := inv.NewMenu(handler, "Anvil", inv.ContainerAnvil{}).WithStacks(stacks...)
inv.SendMenu(player, menu)
```

## Validation

- `go test ./...`
- `go test -race ./...`
- `git diff --check`
- `codex review --uncommitted`
